### PR TITLE
added missing charbuffers comparison step at example_enroll.py

### DIFF
--- a/src/files/examples/example_enroll.py
+++ b/src/files/examples/example_enroll.py
@@ -63,8 +63,7 @@ try:
     f.convertImage(0x02)
 
     ## Compares the charbuffers and creates a template
-    similarity = f.compareCharacteristics()
-    if similarity > 50:
+    if f.compareCharacteristics() != 0:
         f.createTemplate()
         ## Saves template at new position number
         positionNumber = f.storeTemplate()

--- a/src/files/examples/example_enroll.py
+++ b/src/files/examples/example_enroll.py
@@ -63,7 +63,15 @@ try:
     f.convertImage(0x02)
 
     ## Compares the charbuffers and creates a template
-    f.createTemplate()
+    similarity = f.compareCharacteristics()
+    if similarity > 50:
+        f.createTemplate()
+        ## Saves template at new position number
+        positionNumber = f.storeTemplate()
+        print('Finger enrolled successfully!')
+        print('New template position #' + str(positionNumber))
+    else:
+        print('Fingerprints do not match')
 
     ## Saves template at new position number
     positionNumber = f.storeTemplate()


### PR DESCRIPTION
This is a fix to `example_enroll.py` which was not conducting charbuffers comparison although mentioned in the comments. The finger saving was done based on the first detected finger regardless the similarity with second.
Now it compares both fingers and based on a similarity level (50) it decides whether accept the enrollment or not.
ljaraque