### PR TITLE
Fixed #48

### DIFF
--- a/src/files/pyfingerprint/pyfingerprint.py
+++ b/src/files/pyfingerprint/pyfingerprint.py
@@ -134,9 +134,6 @@ class PyFingerprint(object):
         @param integer(4 bytes) password
         """
 
-        if ( os.path.exists(port) == False ):
-            raise ValueError('The fingerprint sensor port "' + port + '" was not found!')
-
         if ( baudRate < 9600 or baudRate > 115200 or baudRate % 9600 != 0 ):
             raise ValueError('The given baudrate is invalid!')
 


### PR DESCRIPTION
Removed path existence check: Serial devices are specified by paths on Linux (e.g. `/dev/ttyUSB0`). On Windows they are specified by IDs e.g. `COM3` which are no paths. So the existence check on Windows would always lead to `false`.