### PR TITLE
Improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,17 +7,17 @@ The PyFingerprint library allows to use ZhianTec ZFM-20, ZFM-60, ZFM-70 and ZFM-
 
 ## Package building on Debian
 
-First install the packages for building:
-
-    ~$ sudo apt-get install git devscripts
-
-Than clone this repository:
+Clone this repository:
 
     ~$ git clone https://github.com/bastianraschke/pyfingerprint.git
 
-Build the package:
+Install the packages for building:
 
     ~$ cd ./pyfingerprint/src/
+    ~$ sudo mk-build-deps -i debian/control
+
+Build the package:
+
     ~$ dpkg-buildpackage -uc -us
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The PyFingerprint library allows to use ZhianTec ZFM-20, ZFM-60, ZFM-70 and ZFM-
 
 Install the packages for building:
 
-    ~$ sudo apt-get install git devscripts
+    ~$ sudo apt-get install git devscripts equivs
 
 Clone this repository:
 

--- a/README.md
+++ b/README.md
@@ -7,17 +7,18 @@ The PyFingerprint library allows to use ZhianTec ZFM-20, ZFM-60, ZFM-70 and ZFM-
 
 ## Package building on Debian
 
+Install the packages for building:
+
+    ~$ sudo apt-get install git devscripts
+
 Clone this repository:
 
     ~$ git clone https://github.com/bastianraschke/pyfingerprint.git
 
-Install the packages for building:
+Build the package:
 
     ~$ cd ./pyfingerprint/src/
     ~$ sudo mk-build-deps -i debian/control
-
-Build the package:
-
     ~$ dpkg-buildpackage -uc -us
 
 ## Installation

--- a/doc/PyFingerprint.rst
+++ b/doc/PyFingerprint.rst
@@ -1,0 +1,15 @@
+PyFingerprint
+=============
+
+.. toctree::
+   :maxdepth: 2
+
+.. topic:: Abstract
+
+    Python 2 and 3 library for ZFM fingerprint sensors.
+
+API Documentation
+*****************
+
+.. automodule:: pyfingerprint.pyfingerprint
+   :members:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,14 +1,17 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+import datetime
 import sys
-sys.path.append('../src/files/')
+sys.path.insert(0, '../src/files/')
+
+import pyfingerprint
 
 project = u'PyFingerprint'
 master_doc = 'PyFingerprint'
-copyright = '2019, Bastian Raschke <bastian.raschke@posteo.de>'
 author = 'Bastian Raschke <bastian.raschke@posteo.de>'
-version = __import__('pyfingerprint').__version__
+copyright = '2014-{}, {}'.format(datetime.date.today().year, author.format)
+version = pyfingerprint.__version__
 release = version
 exclude_patterns = [
     '_build',

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -21,3 +21,4 @@ exclude_patterns = [
 extensions = [
     'sphinx.ext.autodoc',
 ]
+autoclass_content = "both"

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,12 +1,15 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+import sys
+sys.path.append('../src/files/')
+
 project = u'PyFingerprint'
 master_doc = 'PyFingerprint'
 copyright = '2019, Bastian Raschke <bastian.raschke@posteo.de>'
 author = 'Bastian Raschke <bastian.raschke@posteo.de>'
-version = '1.5'
-release = '1.5'
+version = __import__('pyfingerprint').__version__
+release = version
 exclude_patterns = [
     '_build',
     'Thumbs.db',

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -10,7 +10,7 @@ import pyfingerprint
 project = u'PyFingerprint'
 master_doc = 'PyFingerprint'
 author = 'Bastian Raschke <bastian.raschke@posteo.de>'
-copyright = '2014-{}, {}'.format(datetime.date.today().year, author.format)
+copyright = '2014-{}, {}'.format(datetime.date.today().year, author)
 version = pyfingerprint.__version__
 release = version
 exclude_patterns = [

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+project = u'PyFingerprint'
+master_doc = 'PyFingerprint'
+copyright = '2019, Bastian Raschke <bastian.raschke@posteo.de>'
+author = 'Bastian Raschke <bastian.raschke@posteo.de>'
+version = '1.5'
+release = '1.5'
+exclude_patterns = [
+    '_build',
+    'Thumbs.db',
+    '.DS_Store'
+]
+extensions = [
+    'sphinx.ext.autodoc',
+]

--- a/src/debian/control
+++ b/src/debian/control
@@ -40,7 +40,7 @@ Description: Python 3 written library for using ZhianTec fingerprint sensors
 Package: python-fingerprint-doc
 Section: doc
 Architecture: all
-Depends: ${misc:Depends}, libjs-jquery, libjs-underscore
+Depends: ${sphinxdoc:Depends}, ${misc:Depends}
 Recommends: python-fingerprint | python3-fingerprint
 Description: API Documentation for PyFingerprint
  Python 2 and 3 written library for using ZhianTec fingerprint sensors. This

--- a/src/debian/control
+++ b/src/debian/control
@@ -9,7 +9,7 @@ Build-Depends: debhelper (>= 9),
                python3 (>= 3.2),
                python-setuptools,
                python3-setuptools,
-               python-sphinx
+               python-sphinx | python3-sphinx
 X-Python-Version: all
 X-Python3-Version: >= 3.2
 Vcs-Git: https://github.com/bastianraschke/pyfingerprint.git

--- a/src/debian/control
+++ b/src/debian/control
@@ -1,14 +1,15 @@
 Source: python-fingerprint
 Maintainer: Philipp Meisberger <team@pm-codeworks.de>
 Section: python
-Priority: optional
+Priority: extra
 Standards-Version: 3.9.8
 Build-Depends: debhelper (>= 9),
                dh-python,
                python (>= 2.7),
                python3 (>= 3.2),
                python-setuptools,
-               python3-setuptools
+               python3-setuptools,
+               python-sphinx
 X-Python-Version: all
 X-Python3-Version: >= 3.2
 Vcs-Git: https://github.com/bastianraschke/pyfingerprint.git
@@ -35,3 +36,12 @@ Description: Python 3 written library for using ZhianTec fingerprint sensors
  Library for using ZhianTec ZFM-20, ZFM-60, ZFM-70 and ZFM-100 fingerprint
  sensors (known as "Arduino fingerprint sensor") in Python 3. Some other models
  like R302, R303, R305, R306, R307, R551 and FPM10A also work.
+
+Package: python-fingerprint-doc
+Section: doc
+Architecture: all
+Depends: ${misc:Depends}, libjs-jquery, libjs-underscore
+Recommends: python-fingerprint | python3-fingerprint
+Description: API Documentation for PyFingerprint
+ Python 2 and 3 written library for using ZhianTec fingerprint sensors. This
+ package contains the API documentation.

--- a/src/debian/control
+++ b/src/debian/control
@@ -1,7 +1,7 @@
 Source: python-fingerprint
 Maintainer: Philipp Meisberger <team@pm-codeworks.de>
 Section: python
-Priority: extra
+Priority: optional
 Standards-Version: 3.9.8
 Build-Depends: debhelper (>= 9),
                dh-python,

--- a/src/debian/control
+++ b/src/debian/control
@@ -44,6 +44,6 @@ Section: doc
 Architecture: all
 Depends: ${sphinxdoc:Depends}, ${misc:Depends}
 Recommends: python-fingerprint | python3-fingerprint
-Description: API Documentation for PyFingerprint
+Description: API documentation for PyFingerprint
  Python 2 and 3 written library for using ZhianTec fingerprint sensors. This
  package contains the API documentation.

--- a/src/debian/control
+++ b/src/debian/control
@@ -20,6 +20,7 @@ Depends: ${python:Depends},
          ${misc:Depends},
          python-serial,
          python-pil
+Suggests: python-fingerprint-doc
 Architecture: all
 Description: Python 2 written library for using ZhianTec fingerprint sensors
  Library for using ZhianTec ZFM-20, ZFM-60, ZFM-70 and ZFM-100 fingerprint
@@ -31,6 +32,7 @@ Depends: ${python3:Depends},
          ${misc:Depends},
          python3-serial,
          python3-pil
+Suggests: python-fingerprint-doc
 Architecture: all
 Description: Python 3 written library for using ZhianTec fingerprint sensors
  Library for using ZhianTec ZFM-20, ZFM-60, ZFM-70 and ZFM-100 fingerprint

--- a/src/debian/python-fingerprint-doc.doc-base
+++ b/src/debian/python-fingerprint-doc.doc-base
@@ -1,0 +1,9 @@
+Document: python-fingerprint-api
+Title: PyFingerprint API
+Author: Bastian Raschke <bastian.raschke@posteo.de>
+Abstract: PyFingerprint API documentation
+Section: Programming
+
+Format: HTML
+Index: /usr/share/doc/python-fingerprint-doc/html/PyFingerprint.html
+Files: /usr/share/doc/python-fingerprint-doc/html/*.html

--- a/src/debian/python-fingerprint-doc.install
+++ b/src/debian/python-fingerprint-doc.install
@@ -1,0 +1,1 @@
+build/html/ /usr/share/doc/python-fingerprint-doc/

--- a/src/debian/rules
+++ b/src/debian/rules
@@ -1,12 +1,14 @@
 #!/usr/bin/make -f
 
 %:
-	dh $@ --with python2,python3
+	dh $@ --with python2,python3,sphinxdoc
 
 override_dh_auto_clean:
 	dh_auto_clean
 	rm -rf ./build/ ./files/*.egg-info/
 
+override_dh_auto_build: export http_proxy=127.0.0.1:9
+override_dh_auto_build: export https_proxy=127.0.0.1:9
 override_dh_auto_build:
 	dh_auto_build
 	set -ex; for python in $(shell py3versions -r); do \
@@ -15,12 +17,6 @@ override_dh_auto_build:
 
 	## Build API documentation
 	sphinx-build -b html ../doc ./build/html
-
-	## Fix Lintian warnings
-	rm ./build/html/_static/jquery.js
-	ln -s /usr/share/javascript/jquery/jquery.js ./build/html/_static/jquery.js
-	rm ./build/html/_static/underscore.js
-	ln -s /usr/share/javascript/underscore/underscore.js ./build/html/_static/underscore.js
 
 override_dh_auto_install:
 	dh_auto_install

--- a/src/debian/rules
+++ b/src/debian/rules
@@ -13,7 +13,10 @@ override_dh_auto_build:
 		$$python setup.py build; \
 	done;
 
+	## Build API documentation
 	sphinx-build -b html ../doc ./build/html
+
+	## Fix Lintian warnings
 	rm ./build/html/_static/jquery.js
 	ln -s /usr/share/javascript/jquery/jquery.js ./build/html/_static/jquery.js
 	rm ./build/html/_static/underscore.js

--- a/src/debian/rules
+++ b/src/debian/rules
@@ -13,6 +13,12 @@ override_dh_auto_build:
 		$$python setup.py build; \
 	done;
 
+	sphinx-build -b html ../doc ./build/html
+	rm ./build/html/_static/jquery.js
+	ln -s /usr/share/javascript/jquery/jquery.js ./build/html/_static/jquery.js
+	rm ./build/html/_static/underscore.js
+	ln -s /usr/share/javascript/underscore/underscore.js ./build/html/_static/underscore.js
+
 override_dh_auto_install:
 	dh_auto_install
 	set -ex; for python in $(shell py3versions -r); do \


### PR DESCRIPTION
The documentation is currently only inside code. We should provide an API documentation for online and offline usage (HTML format). Sphinx is a great choice for that. We could host the API documentation in folder "docs" as single GitHub page. I created a draft for that. I also created a new Debian package "python-fingerprint-doc" for offline API documentation. The used Python doc strings are partially non-Python standard especially for parameters and return values: We should convert them.