### PR TITLE
Fixed #64 downloadImage() exception: image index out of range

### DIFF
--- a/src/files/pyfingerprint/pyfingerprint.py
+++ b/src/files/pyfingerprint/pyfingerprint.py
@@ -744,8 +744,10 @@ class PyFingerprint(object):
                 ## One byte contains two pixels
                 ## Thanks to Danylo Esterman <soundcracker@gmail.com> for the "multiple with 17" improvement:
                 if (x % 2 == 0):
+                    ## Draw left 4 Bits one byte of package
                     pixels[x, y] = (imageData[row][column]  >> 4) * 17
                 else:
+                    ## Draw right 4 Bits one byte of package
                     pixels[x, y] = (imageData[row][column] & 0x0F) * 17
                     column += 1
 


### PR DESCRIPTION
The problem was that incoming packet length was taken as image size which causes the "index out of bounds" exception. Tested with all supported packet lengths. 