### PR TITLE
Fixed "The received packet do not begin with a valid header"

### DIFF
--- a/src/files/pyfingerprint/pyfingerprint.py
+++ b/src/files/pyfingerprint/pyfingerprint.py
@@ -315,6 +315,8 @@ class PyFingerprint(object):
             if ( len(receivedFragment) != 0 ):
                 receivedFragment = self.__stringToByte(receivedFragment)
                 ## print 'Received packet fragment = ' + hex(receivedFragment)
+            else:
+                continue
 
             ## Insert byte if packet seems valid
             receivedPacketData.insert(i, receivedFragment)


### PR DESCRIPTION
This should fix the often reported error: "The received packet do not begin with a valid header"